### PR TITLE
Fjern term

### DIFF
--- a/verifiserte_termer.csv
+++ b/verifiserte_termer.csv
@@ -310,7 +310,6 @@ cotangens,cotangens,cotangent,
 sannsynlighet,sannsyn,likelihood,
 multiplikativt identitetselement,multiplikativt identitetselement,multiplicative identity element,
 brøk,brøk,fraction,
-bijeksjon,bijeksjon,bijection,"Synonym: én-til-én-korrespondanse"
 rettet mengde,retta mengd,directed set,
 topologisk gruppe,topologisk gruppe,topological group,
 irredusibel,irredusibel,irreducible,


### PR DESCRIPTION
Termen foreslås fjernet fordi det bør legges til én-entydig korrespondanse som synonym i merknaden