### PR TITLE
Fjern injektiv

### DIFF
--- a/verifiserte_termer.csv
+++ b/verifiserte_termer.csv
@@ -938,7 +938,6 @@ uniformt kontinuerlig,uniformt kontinuerleg,uniformly continuous,
 konnektiv,konnektiv,connective,
 amplitude,amplitude,amplitude,
 bijektiv,bijektiv,bijective,
-injektiv,injektiv,injective,"Synonym: én-til-én"
 hovedidealområde,hovudidealområde,principal ideal domain,"Hovedidealområde forkortes ofte til PID."
 polarform,polarform,polar form,
 ikosaeder,ikosaeder,icosahedron,


### PR DESCRIPTION
Termen fjernes fordi merknaden må oppdateres til å også inneholde én-entydig som synonym