### PR TITLE
Fjern duplisert term "orden"

### DIFF
--- a/verifiserte_termer.csv
+++ b/verifiserte_termer.csv
@@ -2049,7 +2049,6 @@ Burnsides formel,Burnsides formel,Burnside's formula,
 rotkropp,rotkropp,splitting field,
 p-undergruppe,p-undergruppe,p-subgroup,
 like funksjon,like funksjon,even function,"Oversettelsen jevn funksjon (bokmål) og jamn funksjon (nynorsk) er også i bruk."
-orden,orden,order,
 like permutasjon,like permutasjon,even permutation,"Oversettelsen jevn permutasjon (bokmål) og jamn permutasjon (nynorsk) er også i bruk."
 odde permutasjon,odde permutasjon,odd permutation,
 indeks,indeks,index,


### PR DESCRIPTION
Begrepet er også definert i linje 2319 (etter at linje 2052 er fjernet) med utfyllende kommentar.