### PR TITLE
Legger til CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @jfremstad @johahaug @bervinator @simonfoldvik


### PR DESCRIPTION
* Legger til en `CODEOWNERS`-fil, slik at PR-er automatisk får satt «reviewers».
* Hensikten er å senke tiden det tar for en PR å bli undersøkt og merget/avslått.