### PR TITLE
Legg til `.gitattributes` fil

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.yaml -linguist-generated linguist-detectable
+*.yml -linguist-generated linguist-detectable
+*.csv -linguist-generated linguist-detectable


### PR DESCRIPTION
Denne addisjonen gjør at filtypene YAML og CSV tas med i beregningen av hvilke kodespråk repoet består av. Addisjonen gjør også at disse filtypene ikke lenger behandles som "genererte" av GitHub.