### PR TITLE
Fiks lenker etter reorganisering

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ kommer med forslag til endringer og nye oversettelser.
 - Har du andre forslag som kan gjøre ordlista mer nyttig og brukervennlig?
 
 Alle innspill settes stor pris på. I
-[diskusjonsforumet](https://github.com/jfremstad/matematisk_ordliste/issues) kan
-enhver som ønsker det være med på å diskutere saker som angår ordlista. Forslag
-om endringer går til slutt gjennom en verifikasjonsprosess, før de eventuelt
-publiseres på den offisielle ordlista. Dersom du ønsker å ta en aktiv rolle i
-ordlistens vedlikehold, ta gjerne kontakt på epost
+[diskusjonsforumet](https://github.com/matematisk-ordliste/matematisk-ordliste/issues)
+kan enhver som ønsker det være med på å diskutere saker som angår ordlista.
+Forslag om endringer går til slutt gjennom en verifikasjonsprosess, før de
+eventuelt publiseres på den offisielle ordlista. Dersom du ønsker å ta en aktiv
+rolle i ordlistens vedlikehold, ta gjerne kontakt på epost
 ([ordliste@matematikkradet.no](mailto:ordliste@matematikkradet.no)).
 
 Her kan du lese om hvordan du kan

--- a/dokumentasjon/innspill.md
+++ b/dokumentasjon/innspill.md
@@ -1,18 +1,18 @@
 # Hvordan komme med innspill
 
 Hvis du ikke har bruker på denne plattformen (GitHub), kan du opprette en
-[her](https://github.com/join?return_to=https%3A%2F%2Fgithub.com%2Fjfremstad%2Fmatematisk_ordliste%2Fblob%2Fmaster%2Fdokumentasjon%2Finnspill.md).
+[her](https://github.com/join?return_to=https%3A%2F%2Fgithub.com%2Fmatematisk-ordliste%2Fmatematisk-ordliste%2Fblob%2Fmaster%2Fdokumentasjon%2Finnspill.md).
 Du kan også sende innspill på mail til
 [ordliste@matematikkradet.no](mailto:ordliste@matematikkradet.no).
 
 ### Delta i diskusjonsforumet
 
 1. Sjekk i listen over
-   [åpne diskusjonstråder](https://github.com/jfremstad/matematisk_ordliste/issues)
+   [åpne diskusjonstråder](https://github.com/matematisk-ordliste/matematisk-ordliste/issues)
    om det allerede finnes en tråd som passer til ditt innspill. Her kan det være
    lurt å bruke søkefunksjonen.
 1. Du kan opprette din egen diskusjonstråd ved å
-   [trykke her.](https://github.com/jfremstad/matematisk_ordliste/issues/new/choose)
+   [trykke her.](https://github.com/matematisk-ordliste/matematisk-ordliste/issues/new/choose)
    Bruk de forhåndslagde malene eller formuler innlegget ditt slik du selv synes
    passer best.
 
@@ -23,7 +23,7 @@ Du kan også sende innspill på mail til
    skulle være uenig i disse, kan du opprette en diskusjonstråd.
 1. Sjekk at du skriver ned oversettelsen eller endringen i
    [riktig format](foering_av_termer.md).
-1. [Her](https://github.com/jfremstad/matematisk_ordliste/edit/master/verifiserte_termer.csv)
+1. [Her](https://github.com/matematisk-ordliste/matematisk-ordliste/edit/master/verifiserte_termer.csv)
    kan du endre fila og lagre. Du oppretter da et endringsforslag som andre kan
    se på, før det eventuelt publiseres på den offisielle ordlista. Hvis du
    legger til nye termer, skal disse alltid legges til på enden av dokumentet

--- a/nettside/index.html
+++ b/nettside/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="no">
   <head>
     <script>
@@ -66,7 +66,7 @@
       det er ønskelig at flest mulig kommer med forslag til endringer og nye
       oversettelser. På
       <a
-        href="https://github.com/jfremstad/matematisk_ordliste#prosjektside---matematisk-ordliste"
+        href="https://github.com/matematisk-ordliste/matematisk-ordliste#prosjektside---matematisk-ordliste"
         >prosjektsiden</a
       >
       finner du informasjon om hvordan du kan komme med innspill, samt en


### PR DESCRIPTION
Fikser lenker til prosjektsiden siden den har fått et nytt hjem under @matematisk-ordliste organisasjonen.